### PR TITLE
Speed up by-day queries using a materialized view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'kinesis-stream-reader', require: 'stream_reader', github: 'ello/kinesis-str
 gem 'interactor-rails'
 gem 'dotenv-rails'
 gem 'newrelic_rpm'
+gem 'scenic'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,9 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    scenic (1.3.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     slop (3.6.0)
@@ -240,6 +243,7 @@ DEPENDENCIES
   rails_12factor
   rspec-rails
   rspec-rails-time-metadata
+  scenic
   shoulda-matchers
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Therefore, the new architecture consists of a few components:
 
 - Stream raw event data for post impressions via Kinesis from the Mothership (our main Rails app)
 - Store raw impressions in a local database (which is what this project handles)
-- Aggregate counts by dimensions of author/user, and stash them in fast storage (which is handled by [a Spark job](https://github.com/ello/spark-jobs))
+- Aggregate counts in realtime by dimensions of author/user, and stash them in fast storage (which is handled by [a Spark job](https://github.com/ello/spark-jobs))
+- Aggregate counts in batch-time by dimensions of date for reporting purposes (handled via Postgres materialized views)
 
 ## Quickstart
 
@@ -66,13 +67,10 @@ standard:
 The app is pre-packaged for deployment on Heroku, so it should work to fork and
 re-push to your own Heroku remote after you create an app. A couple of caveats:
 
-- You'll need to provision a Redis instance as
-  [kinesis-stream-reader](https://github.com/ello/kinesis-stream-reader) assumes
-  that one will be available to store its local state.
-- You'll need an appropriately-sized Postgres DB addon (though a basic one
-  should be there for you by default)
-- You'll need to specify the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-  `AWS_REGION`, and `KINESIS_STREAM_NAME` environment variables
+- You'll need to provision a Redis instance as [kinesis-stream-reader](https://github.com/ello/kinesis-stream-reader) assumes that one will be available to store its local state.
+- You'll need an appropriately-sized Postgres DB addon (though a basic one should be there for you by default)
+- You'll need to specify the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and `KINESIS_STREAM_NAME` environment variables
+- You'll need to run the `views:refresh` Rake task periodically via Heroku Scheduler (or similar) to get the reporting views refreshed for efficient queries.
 
 ## License
 This project is released under the [MIT License](blob/master/LICENSE.txt)

--- a/db/migrate/20161208001535_create_impressions_by_days.rb
+++ b/db/migrate/20161208001535_create_impressions_by_days.rb
@@ -1,0 +1,6 @@
+class CreateImpressionsByDays < ActiveRecord::Migration
+  def change
+    create_view :impressions_by_days, materialized: true
+    add_index :impressions_by_days, :day, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161101113557) do
+ActiveRecord::Schema.define(version: 20161208001535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "ar_internal_metadata", primary_key: "key", id: :string, force: :cascade do |t|
+    t.string   "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "impressions", id: false, force: :cascade do |t|
     t.string   "viewer_id"
@@ -23,5 +29,15 @@ ActiveRecord::Schema.define(version: 20161101113557) do
     t.index ["author_id", "post_id", "created_at"], name: "index_impressions_on_author_id_and_post_id_and_created_at", unique: true, using: :btree
     t.index ["created_at"], name: "index_impressions_brin_on_created_at", using: :brin
   end
+
+
+  create_view :impressions_by_days, materialized: true,  sql_definition: <<-SQL
+      SELECT date_trunc('day'::text, impressions.created_at) AS day,
+      count(1) AS ct
+     FROM impressions
+    GROUP BY (date_trunc('day'::text, impressions.created_at));
+  SQL
+
+  add_index "impressions_by_days", ["day"], name: "index_impressions_by_days_on_day", unique: true, using: :btree
 
 end

--- a/db/views/impressions_by_days_v01.sql
+++ b/db/views/impressions_by_days_v01.sql
@@ -1,0 +1,5 @@
+select
+  date_trunc('day',created_at) as day
+  , count(1) as ct
+from impressions
+group by 1

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,0 +1,5 @@
+namespace :views do
+  task refresh: :environment do
+    Scenic.database.refresh_materialized_view('impressions_by_days', concurrently: false)
+  end
+end


### PR DESCRIPTION
Expose a `views:refresh` rake task to refresh the view, and add a unique index so it can be refreshed concurrently. This will need to be scheduled via Heroku’s scheduler or similar.

Bring in [scenic](https://github.com/thoughtbot/scenic) to manage the view.