### PR TITLE
Drop ActiveRecord validations when inserting

### DIFF
--- a/app/models/impression.rb
+++ b/app/models/impression.rb
@@ -1,5 +1,3 @@
 class Impression < ApplicationRecord
   include TransactionSkipping
-
-  validates :post_id, :author_id, :created_at, presence: true
 end

--- a/spec/models/impression_spec.rb
+++ b/spec/models/impression_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Impression, type: :model do
-  it { is_expected.to validate_presence_of(:post_id) }
-  it { is_expected.to validate_presence_of(:author_id) }
-  it { is_expected.to validate_presence_of(:created_at) }
-
   describe 'preventing duplicates' do
     it 'does not allow duplicate impressions to be created' do
       attrs = { post_id: "1", author_id: "1", created_at: Time.zone.now }
       expect { 2.times { Impression.create!(attrs) } }.to raise_exception(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does not allow invalid impressions to be created' do
+      expect { 2.times { Impression.create!({}) } }.to raise_exception(ActiveRecord::StatementInvalid)
     end
   end
 end


### PR DESCRIPTION
These will be caught by Postgres anyway, no need to do them in Ruby too. Might make the inserts a tiny bit faster too.