### PR TITLE
Populate a `stream` value if it’s provided

### DIFF
--- a/app/interactors/create_event_from_stream.rb
+++ b/app/interactors/create_event_from_stream.rb
@@ -16,6 +16,7 @@ class CreateEventFromStream
         Impression.create!(author_id: record.dig('author', 'id'),
                           viewer_id: record.dig('viewer', 'id'),
                           post_id: record.dig('post', 'id'),
+                          stream: record['stream'],
                           created_at: Time.at(record['viewed_at']))
       end
     rescue ActiveRecord::RecordNotUnique => e

--- a/db/migrate/20170103213513_add_stream_to_impressions.rb
+++ b/db/migrate/20170103213513_add_stream_to_impressions.rb
@@ -1,0 +1,5 @@
+class AddStreamToImpressions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :impressions, :stream, :string
+  end
+end

--- a/db/migrate/20170104173425_create_impressions_by_stream_by_days.rb
+++ b/db/migrate/20170104173425_create_impressions_by_stream_by_days.rb
@@ -1,0 +1,6 @@
+class CreateImpressionsByStreamByDays < ActiveRecord::Migration
+  def change
+    create_view :impressions_by_stream_by_day, materialized: true
+    add_index :impressions_by_stream_by_day, [:stream, :day], unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -121,7 +121,8 @@ CREATE TABLE impressions (
     viewer_id character varying,
     post_id character varying NOT NULL,
     author_id character varying NOT NULL,
-    created_at timestamp(4) without time zone NOT NULL
+    created_at timestamp(4) without time zone NOT NULL,
+    stream character varying
 );
 
 
@@ -378,6 +379,6 @@ CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW E
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101');
+INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -139,6 +139,19 @@ CREATE MATERIALIZED VIEW impressions_by_days AS
 
 
 --
+-- Name: impressions_by_stream_by_day; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW impressions_by_stream_by_day AS
+ SELECT date_trunc('day'::text, impressions.created_at) AS day,
+    impressions.stream,
+    count(1) AS ct
+   FROM impressions
+  GROUP BY (date_trunc('day'::text, impressions.created_at)), impressions.stream
+  WITH NO DATA;
+
+
+--
 -- Name: impressions_p2016_12_16; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -360,6 +373,13 @@ CREATE UNIQUE INDEX index_impressions_by_days_on_day ON impressions_by_days USIN
 
 
 --
+-- Name: index_impressions_by_stream_by_day_on_stream_and_day; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_impressions_by_stream_by_day_on_stream_and_day ON impressions_by_stream_by_day USING btree (stream, day);
+
+
+--
 -- Name: index_impressions_on_created_at_and_author_id_and_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -379,6 +399,6 @@ CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW E
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513');
+INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513'), ('20170104173425');
 
 

--- a/db/views/impressions_by_stream_by_day_v01.sql
+++ b/db/views/impressions_by_stream_by_day_v01.sql
@@ -1,0 +1,6 @@
+select
+  date_trunc('day',created_at) as day
+  , stream
+  , count(1) as ct
+from impressions
+group by 1,2

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,5 +1,6 @@
 namespace :views do
   task refresh: :environment do
     Scenic.database.refresh_materialized_view('impressions_by_days', concurrently: true)
+    Scenic.database.refresh_materialized_view('impressions_by_stream_by_day', concurrently: true)
   end
 end

--- a/spec/interactors/create_event_from_stream_spec.rb
+++ b/spec/interactors/create_event_from_stream_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CreateEventFromStream, type: :model, freeze_time: true do
       { 'author'    => { 'id' => '1' },
         'post'      => { 'id' => '10' },
         'viewer'    => { 'id' => '2' },
+        'stream'    => 'recent',
         'viewed_at' => Time.now.to_f }
     end
 
@@ -17,6 +18,7 @@ RSpec.describe CreateEventFromStream, type: :model, freeze_time: true do
       expect(last_impression.author_id).to eq('1')
       expect(last_impression.post_id).to eq('10')
       expect(last_impression.viewer_id).to eq('2')
+      expect(last_impression.stream).to eq('recent')
       expect(last_impression.created_at).to eq(Time.now)
     end
 
@@ -32,6 +34,7 @@ RSpec.describe CreateEventFromStream, type: :model, freeze_time: true do
     let(:record) do
       { 'author'    => { 'id' => '1' },
         'post'      => { 'id' => '10' },
+        'stream'    => 'recent',
         'viewed_at' => Time.now.to_f }
     end
 
@@ -42,6 +45,25 @@ RSpec.describe CreateEventFromStream, type: :model, freeze_time: true do
       expect(last_impression.author_id).to eq('1')
       expect(last_impression.post_id).to eq('10')
       expect(last_impression.viewer_id).to be_nil
+      expect(last_impression.stream).to eq('recent')
+      expect(last_impression.created_at).to eq(Time.now)
+    end
+  end
+
+  describe 'with a record that has no stream' do
+    let(:record) do
+      { 'author'    => { 'id' => '1' },
+        'post'      => { 'id' => '10' },
+        'viewed_at' => Time.now.to_f }
+    end
+
+    it 'stores an impression model' do
+      described_class.call(kind: 'post_was_viewed', record:  record)
+      expect(Impression.count).to eq(1)
+      last_impression = Impression.first
+      expect(last_impression.author_id).to eq('1')
+      expect(last_impression.post_id).to eq('10')
+      expect(last_impression.stream).to be_nil
       expect(last_impression.created_at).to eq(Time.now)
     end
   end


### PR DESCRIPTION
This will let us aggregate impression counts on the source stream dimension, in addition to the author, post, date, and viewer.

- [x] Create a column for stream and populate it if present in the Avro payload
- [x] Ensure that both stream-present and stream-absent records save properly
- [x] Create a materialized view to aggregate counts by stream by day