### PR TITLE
Add btree index to impressions viewer_id

### DIFF
--- a/db/migrate/20170221035451_add_index_on_impressions_viewer_id.rb
+++ b/db/migrate/20170221035451_add_index_on_impressions_viewer_id.rb
@@ -1,0 +1,7 @@
+class AddIndexOnImpressionsViewerId < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :impressions, :viewer_id, using: :btree, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -430,7 +430,14 @@ CREATE UNIQUE INDEX index_impressions_on_created_at_and_author_id_and_post_id ON
 
 
 --
--- Name: impressions impressions_part_trig; Type: TRIGGER; Schema: public; Owner: -
+-- Name: index_impressions_on_viewer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impressions_on_viewer_id ON impressions USING btree (viewer_id);
+
+
+--
+-- Name: impressions_part_trig; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW EXECUTE PROCEDURE impressions_part_trig_func();
@@ -442,6 +449,6 @@ CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW E
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513'), ('20170104173425'), ('20170118203315'), ('20170118203716'), ('20170119233648'), ('20170130163030');
+INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513'), ('20170104173425'), ('20170118203315'), ('20170118203716'), ('20170119233648'), ('20170130163030'), ('20170221035451');
 
 


### PR DESCRIPTION
- While updating our post views for logged in/out users chart to use the
grandstand DB, our queries were timing out. This should prevent that.