### PR TITLE
Ensure email active users are recalculated.

### DIFF
--- a/app/interactors/update_daily_email_active_user_rollups.rb
+++ b/app/interactors/update_daily_email_active_user_rollups.rb
@@ -3,10 +3,10 @@ class UpdateDailyEmailActiveUserRollups
   include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
 
   def call
-    EmailActiveUserRollup.find_or_create_by(day: context.date) do |mau|
-      mau.day_total        = day_total
-      mau.thirty_day_total = rolling_total
-    end
+    mau = EmailActiveUserRollup.where(day: context.date).first_or_initialize
+    mau.day_total        = day_total
+    mau.thirty_day_total = rolling_total
+    mau.save
   end
 
   private

--- a/spec/interactors/update_daily_email_active_user_rollups_spec.rb
+++ b/spec/interactors/update_daily_email_active_user_rollups_spec.rb
@@ -51,4 +51,53 @@ RSpec.describe UpdateDailyEmailActiveUserRollups, type: :model, freeze_time: tru
     expect(email_mau.day_total).to eq(2)
     expect(email_mau.thirty_day_total).to eq(2)
   end
+
+  it 'updates existing records' do
+    Impression.create(
+      created_at: DateTime.new(2017, 1, 1, 12, 15),
+      stream_kind: 'email',
+      stream_id: 1,
+      author_id: 0,
+      post_id: 0,
+      viewer_id: 1,
+    )
+    Impression.create(
+      created_at: DateTime.new(2017, 1, 1, 12, 45),
+      stream_kind: 'email',
+      author_id: 0,
+      post_id: 1,
+      viewer_id: 1,
+    )
+    Impression.create(
+      created_at: DateTime.new(2017, 1, 1, 12, 45),
+      stream_kind: 'email',
+      author_id: 0,
+      post_id: 2,
+      viewer_id: nil,
+    )
+    Impression.create(
+      created_at: DateTime.new(2017, 1, 2, 12, 15),
+      stream_kind: 'email',
+      author_id: 0,
+      post_id: 3,
+      viewer_id: 1,
+    )
+    Impression.create(
+      created_at: DateTime.new(2017, 1, 2, 12, 45),
+      stream_kind: 'email',
+      author_id: 0,
+      post_id: 1,
+      viewer_id: 2,
+    )
+    EmailActiveUserRollup.create(
+      day: Date.new(2017, 1, 2),
+      day_total: 0,
+      thirty_day_total: 0
+    )
+    described_class.call(date: Date.new(2017, 1, 2))
+    expect(EmailActiveUserRollup.count).to eq(1)
+    email_mau = EmailActiveUserRollup.first
+    expect(email_mau.day_total).to eq(2)
+    expect(email_mau.thirty_day_total).to eq(2)
+  end
 end


### PR DESCRIPTION
Otherwise totals reflect the first total calculated of the day, not the
total at the end of the day.

Going to have to recalculate the last few days manually.

https://www.pivotaltracker.com/story/show/143377715