### PR TITLE
Drop now-unused reporting views

### DIFF
--- a/db/migrate/20170505160548_drop_materialized_views.rb
+++ b/db/migrate/20170505160548_drop_materialized_views.rb
@@ -1,0 +1,9 @@
+class DropMaterializedViews < ActiveRecord::Migration[5.0]
+  def change
+    drop_view :impressions_by_stream_by_day, revert_to_version: 2, materialized: true
+    drop_view :impressions_by_logged_in_and_out_by_days, revert_to_version: 1, materialized: true
+    drop_view :impressions_by_email_by_days, revert_to_version: 1, materialized: true
+    drop_view :impressions_by_days, revert_to_version: 1, materialized: true
+    drop_view :impressions_by_category_by_days, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -128,81 +128,6 @@ CREATE TABLE impressions (
 
 
 --
--- Name: impressions_by_category_by_days; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW impressions_by_category_by_days AS
- SELECT date_trunc('day'::text, impressions.created_at) AS day,
-    impressions.stream_id AS category,
-    count(1) AS ct
-   FROM impressions
-  WHERE ((impressions.stream_kind)::text = 'category'::text)
-  GROUP BY (date_trunc('day'::text, impressions.created_at)), impressions.stream_id
-  WITH NO DATA;
-
-
---
--- Name: impressions_by_days; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW impressions_by_days AS
- SELECT date_trunc('day'::text, impressions.created_at) AS day,
-    count(1) AS ct
-   FROM impressions
-  GROUP BY (date_trunc('day'::text, impressions.created_at))
-  WITH NO DATA;
-
-
---
--- Name: impressions_by_email_by_days; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW impressions_by_email_by_days AS
- SELECT date_trunc('day'::text, impressions.created_at) AS day,
-    impressions.stream_id AS email,
-    count(1) AS ct
-   FROM impressions
-  WHERE ((impressions.stream_kind)::text = 'email'::text)
-  GROUP BY (date_trunc('day'::text, impressions.created_at)), impressions.stream_id
-  WITH NO DATA;
-
-
---
--- Name: impressions_by_logged_in_and_out_by_days; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW impressions_by_logged_in_and_out_by_days AS
- SELECT date_trunc('day'::text, impressions.created_at) AS day,
-    sum(
-        CASE
-            WHEN (impressions.viewer_id IS NOT NULL) THEN 1
-            ELSE 0
-        END) AS logged_in,
-    sum(
-        CASE
-            WHEN (impressions.viewer_id IS NULL) THEN 1
-            ELSE 0
-        END) AS logged_out,
-    count(1) AS "Post Views/Day"
-   FROM impressions
-  GROUP BY (date_trunc('day'::text, impressions.created_at))
-  WITH NO DATA;
-
-
---
--- Name: impressions_by_stream_by_day; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW impressions_by_stream_by_day AS
- SELECT date_trunc('day'::text, impressions.created_at) AS day,
-    impressions.stream_kind,
-    count(1) AS ct
-   FROM impressions
-  GROUP BY (date_trunc('day'::text, impressions.created_at)), impressions.stream_kind
-  WITH NO DATA;
-
-
---
 -- Name: impressions_p2017_01_14; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -417,41 +342,6 @@ CREATE UNIQUE INDEX impressions_p2017_01_22_created_at_author_id_post_id_idx ON 
 
 
 --
--- Name: index_impressions_by_category_by_days_on_category_and_day; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_impressions_by_category_by_days_on_category_and_day ON impressions_by_category_by_days USING btree (category, day);
-
-
---
--- Name: index_impressions_by_days_on_day; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_impressions_by_days_on_day ON impressions_by_days USING btree (day);
-
-
---
--- Name: index_impressions_by_email_by_days_on_email_and_day; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_impressions_by_email_by_days_on_email_and_day ON impressions_by_email_by_days USING btree (email, day);
-
-
---
--- Name: index_impressions_by_logged_in_and_out_by_days_on_day; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_impressions_by_logged_in_and_out_by_days_on_day ON impressions_by_logged_in_and_out_by_days USING btree (day);
-
-
---
--- Name: index_impressions_by_stream_by_day_on_stream_kind_and_day; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_impressions_by_stream_by_day_on_stream_kind_and_day ON impressions_by_stream_by_day USING btree (stream_kind, day);
-
-
---
 -- Name: index_impressions_on_created_at_and_author_id_and_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -466,7 +356,7 @@ CREATE INDEX index_impressions_on_viewer_id ON impressions USING btree (viewer_i
 
 
 --
--- Name: impressions_part_trig; Type: TRIGGER; Schema: public; Owner: -
+-- Name: impressions impressions_part_trig; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW EXECUTE PROCEDURE impressions_part_trig_func();
@@ -478,6 +368,6 @@ CREATE TRIGGER impressions_part_trig BEFORE INSERT ON impressions FOR EACH ROW E
 
 SET search_path TO "$user", public;
 
-INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513'), ('20170104173425'), ('20170118203315'), ('20170118203716'), ('20170119233648'), ('20170130163030'), ('20170221035451'), ('20170227170610');
+INSERT INTO schema_migrations (version) VALUES ('20161017153308'), ('20161101113557'), ('20161208001535'), ('20161208200325'), ('20161208200518'), ('20161220042635'), ('20161220042637'), ('20161220045344'), ('20161220145823'), ('20161220154502'), ('20161220235101'), ('20170103213513'), ('20170104173425'), ('20170118203315'), ('20170118203716'), ('20170119233648'), ('20170130163030'), ('20170221035451'), ('20170227170610'), ('20170505160548');
 
 

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,9 +1,0 @@
-namespace :views do
-  task refresh: :environment do
-    Scenic.database.refresh_materialized_view('impressions_by_days', concurrently: true)
-    Scenic.database.refresh_materialized_view('impressions_by_stream_by_day', concurrently: true)
-    Scenic.database.refresh_materialized_view('impressions_by_category_by_days', concurrently: true)
-    Scenic.database.refresh_materialized_view('impressions_by_email_by_days', concurrently: true)
-    Scenic.database.refresh_materialized_view('impressions_by_logged_in_and_out_by_days', concurrently: true)
-  end
-end


### PR DESCRIPTION
We've replaced them with the reporting DB so they're no longer needed.