### PR TITLE
Set up an initializer to read AWS creds from Vault

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development do
 end
 
 group :production do
+  gem 'vault'
   gem 'rails_12factor'
   gem 'honeybadger', '~> 2.0'
 end

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -1,0 +1,10 @@
+if !defined?(Vault)
+  Rails.logger.info 'Vault gem not loaded, using local configuration...'
+else
+  Vault.with_retries(Vault::HTTPConnectionError) do
+    secret = Vault.logical.read('aws/sts/grandstand')
+    ENV['AWS_ACCESS_KEY_ID'] = secret.data[:access_key]
+    ENV['AWS_SECRET_ACCESS_KEY'] = secret.data[:secret_key]
+    ENV['AWS_SESSION_TOKEN'] = secret.data[:security_token]
+  end
+end

--- a/config/initializers/vault.rb
+++ b/config/initializers/vault.rb
@@ -1,8 +1,9 @@
 if !defined?(Vault)
   Rails.logger.info 'Vault gem not loaded, using local configuration...'
 else
+  Vault.auth.approle(ENV['VAULT_ROLE_ID'], ENV['VAULT_SECRET_ID'])
   Vault.with_retries(Vault::HTTPConnectionError) do
-    secret = Vault.logical.read('aws/sts/grandstand')
+    secret = Vault.logical.write('aws/sts/grandstand', ttl: '25h')
     ENV['AWS_ACCESS_KEY_ID'] = secret.data[:access_key]
     ENV['AWS_SECRET_ACCESS_KEY'] = secret.data[:secret_key]
     ENV['AWS_SESSION_TOKEN'] = secret.data[:security_token]


### PR DESCRIPTION
Vault configuration can be set via `VAULT_ADDR` and `VAULT_TOKEN` - falls back to local env vars if Vault isn't present.

As an aside this switches to STS credentials using a session token, [which _ought_ to just work](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/) but could probably use testing before going straight to prod.

Should be able to test once https://github.com/ello/infrastructure/pull/48 is built/up.