### PR TITLE
Make transaction skipping logic threadsafe

### DIFF
--- a/app/models/concerns/transaction_skipping.rb
+++ b/app/models/concerns/transaction_skipping.rb
@@ -5,7 +5,7 @@ module TransactionSkipping
 
   class_methods do
     def transaction(*args)
-      if @skip_transaction
+      if Thread.current[:skip_transaction]
         yield
       else
         super
@@ -14,10 +14,10 @@ module TransactionSkipping
 
     def skip_transaction
       begin
-        @skip_transaction = true
+        Thread.current[:skip_transaction] = true
         yield
       ensure
-        @skip_transaction = nil
+        Thread.current[:skip_transaction] = nil
       end
     end
   end


### PR DESCRIPTION
This wasn't threadsafe previously (and it looks like I even put in a note about it, haha) but we forgot to change it around when we moved to the threaded readers. This fixes that up. Shouldn't be causing many issues but might be doing some weird things the transactions as it currently stands.