### PR TITLE
Explicitly trigger eager loading in Kinesis task

### DIFF
--- a/lib/tasks/kinesis.rake
+++ b/lib/tasks/kinesis.rake
@@ -1,6 +1,9 @@
 namespace :kinesis do
   desc 'Parses and saves events from Kinesis queue'
   task consumer: :environment do
+    # Production eager loading doesn't happen in Rake tasks
+    # We need to force it here since the consuemr is threaded
+    Rails.application.eager_load!
 
     stream = StreamReader.new(
       stream_name: ENV['KINESIS_STREAM_NAME'],


### PR DESCRIPTION
Per http://chrisstump.online/2016/02/12/rails-production-eager-loading/, Rails doesn't trigger eager loading in rake tasks for performance reasons even when it's turned on for the environment in general, so we need to do it manually.

This is likely the cause of a number of Honeybadger errors such as https://app.honeybadger.io/projects/50214/faults/33237503#notice-summary.